### PR TITLE
修复DropDownCascadeList存在的bug

### DIFF
--- a/lib/dropdown/drop_down_cascade_list.dart
+++ b/lib/dropdown/drop_down_cascade_list.dart
@@ -152,8 +152,11 @@ class _DropDownCascadeListState extends State<DropDownCascadeList> {
     widget.dataController?.bind(this);
     multipleChoice =
         widget.maxMultiChoiceSize != null && widget.maxMultiChoiceSize! > 0;
-    if (widget.items.isNotEmpty) {
+    var defaultFirstFloorItem = widget.items.firstWhere((e) => e.check);
+    if (defaultFirstFloorItem.data != null) {
       widget.items.first.check = true;
+    } else {
+      firstFloorIndex = widget.items.indexOf(defaultFirstFloorItem);
     }
     items = List.generate(
       widget.items.length,


### PR DESCRIPTION
级联的数据传入的数据可能已经被选中，如果默认选中第一条记录的话，会存在bug