### PR TITLE
Fix no element error

### DIFF
--- a/lib/dropdown/drop_down_cascade_list.dart
+++ b/lib/dropdown/drop_down_cascade_list.dart
@@ -152,11 +152,11 @@ class _DropDownCascadeListState extends State<DropDownCascadeList> {
     widget.dataController?.bind(this);
     multipleChoice =
         widget.maxMultiChoiceSize != null && widget.maxMultiChoiceSize! > 0;
-    var defaultFirstFloorItem = widget.items.firstWhere((e) => e.check);
-    if (defaultFirstFloorItem.data == null) {
-      widget.items.first.check = true;
+    var anyChecked = widget.items.any((e) => e.check);
+    if (anyChecked) {
+      firstFloorIndex = widget.items.indexWhere((e) => e.check);
     } else {
-      firstFloorIndex = widget.items.indexOf(defaultFirstFloorItem);
+      widget.items.first.check = true;
     }
     items = List.generate(
       widget.items.length,


### PR DESCRIPTION
更新后发现会如果 items 中没设置 check 会抛异常，在 demo 中同样会抛异常

原因是这里调用了 firstWhere 
https://github.com/windows7lake/ll_dropdown_menu/blob/main/lib/dropdown/drop_down_cascade_list.dart#L155

而 dart iterator 的 firstWhere 方法如果没有找到 element 且 orElse 没有设置，就会抛异常

![image](https://github.com/user-attachments/assets/521e955c-4ce5-4aee-95c7-8c22079c580d)

## before

![image](https://github.com/user-attachments/assets/368dcacf-2df7-4026-9303-c0954c524862)

## after

![image](https://github.com/user-attachments/assets/0bf34096-9ddd-4de2-9fe6-bac85f09df00)
